### PR TITLE
add host mode - similar as the behavior of microk8s

### DIFF
--- a/cmd/ekz/create_cluster.go
+++ b/cmd/ekz/create_cluster.go
@@ -25,6 +25,11 @@ var createClusterCmd = &cobra.Command{
   # Create the 'dev' cluster (alternative syntax)
   ekz create cluster dev
 
+  # Create the default cluster in the host mode
+  # This command runs the cluster using all (net,ipc,pid,uts) host namespaces, 
+  # similar to run it directly on the local machine. 
+  ekz create cluster --host
+
   # Create an EKS-D cluster with the EKZ provider
   # This command creates an EKS-D-compatible K0s-based cluster.
   ekz --provider=ekz create cluster
@@ -38,7 +43,7 @@ var createClusterCmd = &cobra.Command{
   ekz create cluster -o kubeconfig
 
   # Create EKS-D cluster with a specific version of EKS-D
-  ekz create --eksd-version=v1.18.9-eks-1-18-1 cluster 
+  ekz create --eksd-version=v1.18.9-eks-1-18-1 cluster
 `,
 	RunE: createClusterCmdRun,
 }
@@ -47,12 +52,14 @@ var (
 	eksdVersion    string
 	kubeConfigFile string
 	clusterName    string
+	hostMode       bool
 )
 
 func init() {
 	createClusterCmd.Flags().StringVar(&eksdVersion, "eksd-version", "v1.18.9-eks-1-18-1", "specify a version of EKS-D")
 	createClusterCmd.Flags().StringVarP(&kubeConfigFile, "output", "o", constants.BackTickHomeFile, "specify output file to write kubeconfig to")
 	createClusterCmd.Flags().StringVar(&clusterName, "name", "ekz", "cluster name")
+	createClusterCmd.Flags().BoolVar(&hostMode, "host", false, "run in the host mode")
 
 	createCmd.AddCommand(createClusterCmd)
 }

--- a/cmd/ekz/delete_cluster.go
+++ b/cmd/ekz/delete_cluster.go
@@ -75,6 +75,12 @@ func deleteClusterEKZRun() error {
 		return errors.Errorf("container %s does not exist - cluster deletion aborted", containerName)
 	}
 
+	// TODO check if it's the host mode
+	networkName, err := getNetworkName(containerName)
+	if err != nil {
+		return err
+	}
+
 	err = script.Exec("docker", "rm",
 		"-f", // force delete
 		"-v", // remove volume
@@ -84,13 +90,14 @@ func deleteClusterEKZRun() error {
 		return errors.Wrapf(err, "failed to remove %s", containerName)
 	}
 
-	// remove bridge after deleting the cluster
-	bridgeName := fmt.Sprintf("ekz-%s-bridge", clusterName)
-	err = script.Exec("docker", "network", "rm", bridgeName).Run()
-	if err != nil {
-		return errors.Wrapf(err, "failed to remove bridge: %s", bridgeName)
+	if networkName != "host" {
+		// remove bridge after deleting the cluster
+		bridgeName := fmt.Sprintf("ekz-%s-bridge", clusterName)
+		err = script.Exec("docker", "network", "rm", bridgeName).Run()
+		if err != nil {
+			return errors.Wrapf(err, "failed to remove bridge: %s", bridgeName)
+		}
 	}
-
 	return nil
 }
 

--- a/cmd/ekz/main.go
+++ b/cmd/ekz/main.go
@@ -27,7 +27,7 @@ All EKS-D cluster is single-node and run inside Docker.`,
 	Example: `  # Create an EKS-D cluster with the default provider
   ekz create cluster
 
-  # Delete the cluster
+  # Delete the default cluster
   ekz delete cluster
 
   # List all clusters

--- a/docs/cmd/ekz.md
+++ b/docs/cmd/ekz.md
@@ -14,7 +14,7 @@ All EKS-D cluster is single-node and run inside Docker.
   # Create an EKS-D cluster with the default provider
   ekz create cluster
 
-  # Delete the cluster
+  # Delete the default cluster
   ekz delete cluster
 
   # List all clusters

--- a/docs/cmd/ekz_create_cluster.md
+++ b/docs/cmd/ekz_create_cluster.md
@@ -23,6 +23,11 @@ ekz create cluster [flags]
   # Create the 'dev' cluster (alternative syntax)
   ekz create cluster dev
 
+  # Create the default cluster in the host mode
+  # This command runs the cluster using all (net,ipc,pid,uts) host namespaces, 
+  # similar to run it directly on the local machine. 
+  ekz create cluster --host
+
   # Create an EKS-D cluster with the EKZ provider
   # This command creates an EKS-D-compatible K0s-based cluster.
   ekz --provider=ekz create cluster
@@ -36,7 +41,7 @@ ekz create cluster [flags]
   ekz create cluster -o kubeconfig
 
   # Create EKS-D cluster with a specific version of EKS-D
-  ekz create --eksd-version=v1.18.9-eks-1-18-1 cluster 
+  ekz create --eksd-version=v1.18.9-eks-1-18-1 cluster
 
 ```
 
@@ -45,6 +50,7 @@ ekz create cluster [flags]
 ```
       --eksd-version string   specify a version of EKS-D (default "v1.18.9-eks-1-18-1")
   -h, --help                  help for cluster
+      --host                  run in the host mode
       --name string           cluster name (default "ekz")
   -o, --output string         specify output file to write kubeconfig to (default "~/.kube/config")
 ```


### PR DESCRIPTION
Microk8s installed via `snap` and runs EKS-D locally using the host network and other host namespaces.
The EKZ host mode replicates the same behaviour, but still using container as the rootfs instead of the technique used by `snap`. 

Other than that, the EKZ host mode runs the EKS-D cluster using host's network, pid, ipc, uts namespaces so it's just like the cluster is running directly on the local machine.