### PR TITLE
Remove container after pressed Ctrl+C when running ui in verbose mode

### DIFF
--- a/cmd/ekz/ui.go
+++ b/cmd/ekz/ui.go
@@ -80,7 +80,8 @@ func uiCmdRun(cmd *cobra.Command, args []string) error {
 	logger.Waitingf("press Ctrl + C to stop the UI.")
 
 	if verbose {
-		out, err := script.Exec("docker", "run", "--network=host",
+		out, err := script.Exec("docker", "run",
+			"--rm", "--network=host",
 			"-v", expandKubeConfigFile()+":/root/.kube/config",
 			uiImage,
 		).CombinedOutput()


### PR DESCRIPTION
The ekz ui container will not remove when running with `ekz ui --verbose`.
Fixes by add `--rm` to docker run command.